### PR TITLE
151538701 Use appropriate error codes in response

### DIFF
--- a/server/controllers/ErrorHandler.js
+++ b/server/controllers/ErrorHandler.js
@@ -13,7 +13,7 @@ export default function errorHandler() {
     const sequelize = models.sequelize;
     if (!err.code || err.code > 499) {
       if (err instanceof sequelize.ValidationError) {
-        err.code = 400;
+        err.code = 422;
       } else {
         err.code = 500;
         err.message = 'Exception 500! Operation failed.';

--- a/server/controllers/GroupController.js
+++ b/server/controllers/GroupController.js
@@ -96,7 +96,7 @@ class GroupController {
         if (group) {
           const err = new Error();
           err.message = `You have an existing group ${req.body.name}`;
-          err.code = 400;
+          err.code = 422;
           throw err;
         }
       })

--- a/server/controllers/UserController.js
+++ b/server/controllers/UserController.js
@@ -41,11 +41,11 @@ class UserController {
     return (req, res, next) => {
       if (req.method !== 'POST') {
         const err = new Error('POST request method expected');
-        err.code = 400;
+        err.code = 422;
         return next(err);
       } else if (!req.body.username || !req.body.password) {
         const err = new Error('non-empty username and password expected');
-        err.code = 400;
+        err.code = 422;
         return next(err);
       }
       return next();
@@ -67,7 +67,7 @@ class UserController {
       || req.cookies.token || req.query.token;
       if (!token) {
         const err = new Error('No Access token provided!');
-        err.code = 400;
+        err.code = 422;
         return next(err);
       }
       const matched = /^Bearer (\S+)$/.exec(token);

--- a/server/services/AdhocModelService.js
+++ b/server/services/AdhocModelService.js
@@ -17,7 +17,7 @@ class AdhocModelService {
    */
   static validateInputs(model, fields) {
     const error = new Error();
-    error.code = 400;
+    error.code = 422;
     if (model.name === 'Group') {
       const { name } = fields;
       if (name === undefined) {
@@ -68,7 +68,7 @@ class AdhocModelService {
     .then((groupInstance) => {
       if (!username) {
         const err = new Error('Username is invalid or not defined');
-        err.code = 400;
+        err.code = 422;
         throw err;
       } else {
         return Promise.all([
@@ -80,7 +80,7 @@ class AdhocModelService {
             const err = (isValid[0]) ?
             new Error('User already belong to group')
             : new Error('User does not exist');
-            err.code = 400;
+            err.code = 422;
             throw err;
           }
           return groupInstance.addUser(username)
@@ -111,7 +111,7 @@ class AdhocModelService {
           return user;
         }
         const err = new Error('User does not exist in group');
-        err.code = 400;
+        err.code = 422;
         throw err;
       });
     })

--- a/server/services/ModelService.js
+++ b/server/services/ModelService.js
@@ -141,7 +141,7 @@ class ModelService {
   static processError(message, model, err) {
     if (!err.code) {
       if (err instanceof model.sequelize.ValidationError) {
-        err.code = 400;
+        err.code = 422;
       } else {
         err.code = 500;
         err.message = message;

--- a/server/tests/routes/group-routes-spec.js
+++ b/server/tests/routes/group-routes-spec.js
@@ -14,8 +14,7 @@ const {
   validGroup,
   anotherValidGroup,
   twitter,
-  emptyName,
-  invalidName
+  emptyName
 } = dummyData.Groups;
 
 describe('/api/v1/group', () => {
@@ -80,7 +79,7 @@ describe('/api/v1/group', () => {
       name: 'newGroup'
     })
     .end((err, res) => {
-      expect(res).to.have.status(400);
+      expect(res).to.have.status(422);
       expect(res).to.be.json;
       expect(res.body.error).to.equal('id already exists!');
       return done();
@@ -95,7 +94,7 @@ describe('/api/v1/group', () => {
       name: validGroup.name
     })
     .end((err, res) => {
-      expect(res).to.have.status(400);
+      expect(res).to.have.status(422);
       expect(res).to.be.json;
       expect(res.body.error).to
       .equal('You have an existing group Nations_pledge');
@@ -108,7 +107,7 @@ describe('/api/v1/group', () => {
     .set('Authorization', `Bearer ${token}`)
     .send(emptyName)
     .end((err, res) => {
-      expect(res).to.have.status(400);
+      expect(res).to.have.status(422);
       expect(res).to.be.json;
       expect(res.body.error).to.have
       .string('Group name cannot be an empty string');
@@ -344,7 +343,7 @@ describe('/api/v1/group/:groupId/message', () => {
     .set('Authorization', `Bearer ${token}`)
     .send(message)
     .end((err, res) => {
-      expect(res).to.have.status(400);
+      expect(res).to.have.status(422);
       expect(res).to.be.json;
       expect(res.body.error).to.equal('id already exists!');
       return done();

--- a/server/tests/routes/user-routes-spec.js
+++ b/server/tests/routes/user-routes-spec.js
@@ -45,7 +45,7 @@ describe('/api/v1/user/signup', () => {
     .post('/api/v1/user/signup')
     .send(incompleteUser)
     .end((err, res) => {
-      expect(res).to.have.status(400);
+      expect(res).to.have.status(422);
       expect(res).to.be.json;
       expect(res.body.error).to
       .equal('Username, password, email and phoneNo required');
@@ -57,7 +57,7 @@ describe('/api/v1/user/signup', () => {
     .post('/api/v1/user/signup')
     .send(validUser)
     .end((err, res) => {
-      expect(res).to.have.status(400);
+      expect(res).to.have.status(422);
       expect(res).to.be.json;
       expect(res.body.error).to.equal('username is not available!');
       return done();
@@ -68,7 +68,7 @@ describe('/api/v1/user/signup', () => {
     .post('/api/v1/user/signup')
     .send({ ...validUser, username: 'emailexists' })
     .end((err, res) => {
-      expect(res).to.have.status(400);
+      expect(res).to.have.status(422);
       expect(res).to.be.json;
       expect(res.body.error).to.equal('email already exists!');
       return done();
@@ -80,7 +80,7 @@ describe('/api/v1/user/signup', () => {
     .post('/api/v1/user/signup')
     .send(emptyUsername)
     .end((err, res) => {
-      expect(res).to.have.status(400);
+      expect(res).to.have.status(422);
       expect(res).to.be.json;
       expect(res.body.error).to.have
       .string('username cannot be an empty string');
@@ -97,7 +97,7 @@ describe('/api/v1/user/signup', () => {
     .post('/api/v1/user/signup')
     .send(emptyEmail)
     .end((err, res) => {
-      expect(res).to.have.status(400);
+      expect(res).to.have.status(422);
       expect(res).to.be.json;
       expect(res.body.error).to.have
       .string('email is invalid');
@@ -112,7 +112,7 @@ describe('/api/v1/user/signup', () => {
     .post('/api/v1/user/signup')
     .send(emptyPassword)
     .end((err, res) => {
-      expect(res).to.have.status(400);
+      expect(res).to.have.status(422);
       expect(res).to.be.json;
       expect(res.body.error).to.have
       .string('password must be at least six characters long');
@@ -125,7 +125,7 @@ describe('/api/v1/user/signup', () => {
     .post('/api/v1/user/signup')
     .send(emptyPhoneNo)
     .end((err, res) => {
-      expect(res).to.have.status(400);
+      expect(res).to.have.status(422);
       expect(res).to.be.json;
       expect(res.body.error).to.have
       .string('mobile number cannot be an empty string');
@@ -164,7 +164,7 @@ describe('/api/v1/user/signin', () => {
       password: '1234567'
     })
     .end((err, res) => {
-      expect(res).to.have.status(400);
+      expect(res).to.have.status(422);
       expect(res).to.be.json;
       expect(res.body.error).to.be
       .equal('POST request method expected');
@@ -180,7 +180,7 @@ describe('/api/v1/user/signin', () => {
       password: ''
     })
     .end((err, res) => {
-      expect(res).to.have.status(400);
+      expect(res).to.have.status(422);
       expect(res).to.be.json;
       expect(res.body.error).to.be
       .equal('non-empty username and password expected');
@@ -196,7 +196,7 @@ describe('/api/v1/user/signin', () => {
       password: '123456'
     })
     .end((err, res) => {
-      expect(res).to.have.status(400);
+      expect(res).to.have.status(422);
       expect(res).to.be.json;
       expect(res.body.error).to.be
       .equal('non-empty username and password expected');
@@ -268,7 +268,7 @@ describe('/api/v1/user/:username', () => {
     chai.request(server)
     .get(`/api/v1/user/${validUser.username}`)
     .end((err, res) => {
-      expect(res).to.have.status(400);
+      expect(res).to.have.status(422);
       expect(res).to.be.json;
       expect(res.body.error).to.equal('No Access token provided!');
       return done();
@@ -321,7 +321,7 @@ describe('/api/v1/user/groups', () => {
     chai.request(server)
     .get('/api/v1/user/groups')
     .end((err, res) => {
-      expect(res).to.have.status(400);
+      expect(res).to.have.status(422);
       expect(res).to.be.json;
       expect(res.body.error).to.equal('No Access token provided!');
       return done();
@@ -376,7 +376,7 @@ describe('/api/v1/user/:username', () => {
       email: 'updateduser@andela.com'
     })
     .end((err, res) => {
-      expect(res).to.have.status(400);
+      expect(res).to.have.status(422);
       expect(res).to.be.json;
       expect(res.body.error).to.equal('No Access token provided!');
       return done();
@@ -390,7 +390,7 @@ describe('/api/v1/user/:username', () => {
       email: 'updateduser@andela.com'
     })
     .end((err, res) => {
-      expect(res).to.have.status(400);
+      expect(res).to.have.status(422);
       expect(res).to.be.json;
       expect(res.body.error).to.equal('No Access token provided!');
       return done();

--- a/server/tests/services/adhoc-model-service-spec.js
+++ b/server/tests/services/adhoc-model-service-spec.js
@@ -110,7 +110,7 @@ describe('AdhocModelService.addUserToGroup', () => {
     return AdhocModelService
     .addUserToGroup(undefined, groupId)
     .catch((err) => {
-      expect(err.code).to.equal(400);
+      expect(err.code).to.equal(422);
       expect(err.message).to
       .equal('Username is invalid or not defined');
     });
@@ -121,7 +121,7 @@ describe('AdhocModelService.addUserToGroup', () => {
     return AdhocModelService
     .addUserToGroup(username, groupId)
     .catch((err) => {
-      expect(err.code).to.equal(400);
+      expect(err.code).to.equal(422);
       expect(err.message).to
       .equal('User already belong to group');
     });
@@ -246,7 +246,7 @@ describe('AdhocModelService.removeUserFromGroup', () => {
     return AdhocModelService
     .removeUserFromGroup(username, groupId)
     .catch((err) => {
-      expect(err.code).to.equal(400);
+      expect(err.code).to.equal(422);
       expect(err.message).to
       .equal('User does not exist in group');
     });
@@ -327,7 +327,7 @@ describe('AdhocModelService.addMessageToGroup', () => {
     return AdhocModelService
     .addMessageToGroup(message, groupId)
     .catch((err) => {
-      expect(err.code).to.equal(400);
+      expect(err.code).to.equal(422);
       expect(err.message).to
       .equal('Incomplete field; text is required');
     });


### PR DESCRIPTION
#### What does this PR do?
It changes inappropriate error codes
#### Description of Task to be completed?
Change error code 400 to 422 if request is syntactically correct but invalid
#### How should this be manually tested?
- [Setup application](https://github.com/tomipaul/PostIt/blob/develop/README.md)
- Using Postman, make a call to an endpoint with incorrect parameters
e.g Attempt to sign in with a null password
#### What are the relevant pivotal tracker stories?
#151538701 User should receive error code 422 when request is syntactically correct but invalid.